### PR TITLE
Fix sms API

### DIFF
--- a/lib/taxamo.rb
+++ b/lib/taxamo.rb
@@ -1040,7 +1040,7 @@ module Taxamo
     end
 
     def create_s_m_s_token (body,opts={})
-      query_param_keys = []
+      query_param_keys = [:country_code, :recipient]
 
       # verify existence of params
       raise "body is required" if body.nil?


### PR DESCRIPTION
According the the [API documentation](https://www.taxamo.com/apidocs/api/v1/verification/docs.html#POSTsms), the endpoint `POST /api/v1/verification/sms` require `country_code` and `recipient` params

Those params are not whitelisted in the Taxamo-ruby lib, preventing any usage of the API.
