### PR TITLE
Change: only output requests if logger is configured

### DIFF
--- a/lib/swagger.rb
+++ b/lib/swagger.rb
@@ -30,7 +30,7 @@ module Swagger
       yield(configuration) if block_given?
 
       # Configure logger.  Default to use Rails
-      self.logger ||= configuration.logger || (defined?(Rails) ? Rails.logger : Logger.new(STDOUT))
+      self.logger ||= configuration.logger || (defined?(Rails) ? Rails.logger : Logger.new(STDOUT, level: Logger::WARN))
 
       # remove :// from scheme
       configuration.scheme.sub!(/:\/\//, '')

--- a/lib/swagger/request.rb
+++ b/lib/swagger/request.rb
@@ -145,9 +145,9 @@ module Swagger
     end
   
     def make
-      puts self.configuration
-      logger = Logger.new STDOUT
-      logger.debug self.url
+      if self.configuration && self.configuration.logger
+        self.configuration.logger.debug self.url
+      end
       response = case self.http_method.to_sym
       when :get,:GET
         Typhoeus::Request.get(


### PR DESCRIPTION
- Changes the logger's default level from `info` to `warn`.
- Changes the swagger request object to only log using the logger defined the configuration